### PR TITLE
dpll: move set priority to pin instead of dpll

### DIFF
--- a/drivers/dpll/dpll_core.h
+++ b/drivers/dpll/dpll_core.h
@@ -36,7 +36,7 @@
 struct dpll_pin {
 	int id;
 	enum dpll_pin_type type;
-	int ref_count;
+	refcount_t ref_count;
 	struct dpll_pin_ops *ops;
 	struct mutex lock;
 	void *priv;

--- a/drivers/dpll/dpll_netlink.c
+++ b/drivers/dpll/dpll_netlink.c
@@ -133,8 +133,8 @@ static int __dpll_cmd_dump_sources(struct dpll_device *dpll,
 			}
 			ret = 0;
 		}
-		if (pin->ops->get_prio) {
-			prio = pin->ops->get_prio(pin, dpll);
+		if (dpll->ops->get_prio) {
+			prio = dpll->ops->get_prio(dpll, pin);
 			if (nla_put_u32(msg, DPLLA_SOURCE_PIN_PRIO, prio)) {
 				nla_nest_cancel(msg, src_attr);
 				ret = -EMSGSIZE;
@@ -393,10 +393,10 @@ static int dpll_genl_cmd_set_source_prio(struct sk_buff *skb, struct genl_info *
 
 	mutex_lock(&dpll->lock);
 	pin = dpll_pin_get_by_id(dpll, src_id);
-	if (!pin || !pin->ops || !pin->ops->set_prio)
+	if (!dpll->ops || !dpll->ops->set_prio)
 		ret = -EOPNOTSUPP;
 	else
-		ret = pin->ops->set_prio(pin, dpll, prio);
+		ret = dpll->ops->set_prio(dpll, pin, prio);
 	mutex_unlock(&dpll->lock);
 
 	if (!ret)

--- a/drivers/net/ethernet/intel/ice/ice_synce.c
+++ b/drivers/net/ethernet/intel/ice/ice_synce.c
@@ -361,13 +361,13 @@ static int ice_synce_get_src_select_supported(struct dpll_device *dpll, int mode
 /**
  * ice_synce_get_source_prio
  * @dpll: registered dpll pointer
- * @id: source index
+ * @pin: dpll pin object
  *
  * dpll subsystem callback.
  * Get source priority value.
  * Return: source priority value
  */
-static int ice_synce_get_source_prio(struct dpll_pin *pin, struct dpll_device *dpll)
+static int ice_synce_get_source_prio(struct dpll_device *dpll, struct dpll_pin *pin)
 {
 	struct ice_pf *pf = dpll_priv(dpll);
 	u8 idx = (u8)pin_id(pin);
@@ -389,7 +389,7 @@ static int ice_synce_get_source_prio(struct dpll_pin *pin, struct dpll_device *d
 /**
  * ice_synce_set_source_prio
  * @dpll: registered dpll pointer
- * @id: source index
+ * @pin: dpll pin object
  * @prio: expected priority value
  *
  * dpll subsystem callback.
@@ -398,8 +398,8 @@ static int ice_synce_get_source_prio(struct dpll_pin *pin, struct dpll_device *d
  * * 0 - success
  * * negative - failure
  */
-static int ice_synce_set_source_prio(struct dpll_pin *pin,
-				     struct dpll_device *dpll, int prio)
+static int ice_synce_set_source_prio(struct dpll_device *dpll,
+				     struct dpll_pin *pin, int prio)
 {
 	struct ice_pf *pf = dpll_priv(dpll);
 	u8 idx, priov = (u8)prio;
@@ -435,8 +435,6 @@ static struct dpll_pin_ops ice_synce_source_ops = {
 	.get_type = ice_synce_get_source_type,
 	.set_type = ice_synce_set_source_type,
 	.is_type_supported = ice_synce_get_source_supported,
-	.get_prio = ice_synce_get_source_prio,
-	.set_prio = ice_synce_set_source_prio,
 };
 
 static struct dpll_pin_ops ice_synce_output_ops = {
@@ -450,6 +448,8 @@ static struct dpll_device_ops ice_synce_dpll_ops = {
 	.get_lock_status = ice_synce_get_lock_status,
 	.get_source_select_mode = ice_synce_get_source_select_mode,
 	.get_source_select_mode_supported = ice_synce_get_src_select_supported,
+	.get_prio = ice_synce_get_source_prio,
+	.set_prio = ice_synce_set_source_prio,
 };
 
 /**

--- a/include/linux/dpll.h
+++ b/include/linux/dpll.h
@@ -22,6 +22,8 @@ struct dpll_device_ops {
 	int (*get_source_supported)(struct dpll_device *dpll, int sma, int type);
 	int (*get_output_type)(struct dpll_device *dpll, int sma);
 	int (*get_output_supported)(struct dpll_device, int sma, int type);
+	int (*get_prio)(struct dpll_device *dpll, struct dpll_pin *pin);
+	int (*set_prio)(struct dpll_device *dpll, struct dpll_pin *pin, int prio);
 };
 
 struct dpll_pin_ops {
@@ -30,8 +32,6 @@ struct dpll_pin_ops {
 	int (*set_type)(struct dpll_pin *pin, int type);
 	int (*set_source)(struct dpll_pin *pin, struct dpll_device *dpll, int id);
 	int (*set_flags)(struct dpll_pin *pin, struct dpll_device *dpll, int flags);
-	int (*get_prio)(struct dpll_pin *pin, struct dpll_device *dpll);
-	int (*set_prio)(struct dpll_pin *pin, struct dpll_device *dpll, int prio);
 };
 
 enum dpll_pin_type {


### PR DESCRIPTION
Previous implementation created ops for dedicated to pin object that allows to set/get pin priority.
However priority of the pin may differ between various dplls.

That is why this feature has been moved to dpll ops.

Co-developed-by: Arkadiusz Kubalewski <arkadiusz.kubalewski@intel.com>
Signed-off-by: Arkadiusz Kubalewski <arkadiusz.kubalewski@intel.com>
Signed-off-by: Milena Olech <milena.olech@intel.com>